### PR TITLE
feat: add beverages index and show pages

### DIFF
--- a/app/controllers/beverages_controller.rb
+++ b/app/controllers/beverages_controller.rb
@@ -1,0 +1,9 @@
+class BeveragesController < ApplicationController
+  def index
+    @beverages = Beverage.includes(:category).order(created_at: :desc)
+  end
+
+  def show
+    @beverage = Beverage.find(params[:id])
+  end
+end

--- a/app/helpers/beverages_helper.rb
+++ b/app/helpers/beverages_helper.rb
@@ -1,0 +1,2 @@
+module BeveragesHelper
+end

--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -1,0 +1,3 @@
+class Beverage < ApplicationRecord
+  belongs_to :category
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :beverages, dependent: :destroy
+end

--- a/app/views/beverages/index.html.erb
+++ b/app/views/beverages/index.html.erb
@@ -1,0 +1,10 @@
+<h1>お酒一覧</h1>
+
+<ul>
+  <% @beverages.each do |beverage| %>
+    <li>
+      <%= link_to beverage.name, beverage_path(beverage) %>
+      （<%= beverage.category.name %>）
+    </li>
+  <% end %>
+</ul>

--- a/app/views/beverages/show.html.erb
+++ b/app/views/beverages/show.html.erb
@@ -1,0 +1,6 @@
+<h1><%= @beverage.name %></h1>
+
+<p>カテゴリ：<%= @beverage.category.name %></p>
+<p><%= @beverage.description %></p>
+
+<%= link_to "一覧に戻る", beverages_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,8 @@ Rails.application.routes.draw do
 
   root "pages#home"
 
+  resources :beverages, only: %i[index show]
+
   get "up" => "rails/health#show", as: :rails_health_check
 end
+

--- a/db/migrate/20251215100640_create_categories.rb
+++ b/db/migrate/20251215100640_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251215100723_create_beverages.rb
+++ b/db/migrate/20251215100723_create_beverages.rb
@@ -1,0 +1,11 @@
+class CreateBeverages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :beverages do |t|
+      t.string :name
+      t.text :description
+      t.references :category, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_14_152354) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_15_100723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "beverages", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.bigint "category_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_beverages_on_category_id"
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +41,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_14_152354) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "beverages", "categories"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,20 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+Category.destroy_all
+Beverage.destroy_all
+
+sake = Category.create!(name: "日本酒")
+beer = Category.create!(name: "ビール")
+
+Beverage.create!(
+  name: "獺祭 純米大吟醸",
+  description: "華やかな香りとキレのある後味が特徴の日本酒。",
+  category: sake
+)
+
+Beverage.create!(
+  name: "よなよなエール",
+  description: "柑橘系の香りとコクが楽しめるクラフトビール。",
+  category: beer
+)


### PR DESCRIPTION
## 概要
- categories / beverages のモデルを追加
- seedでデータ投入
- お酒一覧（index）/ お酒詳細（show）を実装

## 動作確認
- /beverages 一覧表示
- /beverages/:id 詳細表示