### PR TITLE
chore: remove temporary seed execution from render build

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,4 +5,3 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
-bundle exec rails db:seed   # ← これを一時的に追加


### PR DESCRIPTION
## 概要
Render Freeプラン対策として一時的に追加していた
db:seed 実行処理を削除しました。

## 背景
- 初期データ投入確認が完了したため
- 今後のデプロイで不要な seed 実行を防ぐため
