### PR TITLE
feat: add tasting logs CRUD (mvp)

### DIFF
--- a/app/controllers/tasting_logs_controller.rb
+++ b/app/controllers/tasting_logs_controller.rb
@@ -1,0 +1,38 @@
+class TastingLogsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_tasting_log, only: %i[show destroy]
+
+  def index
+    @tasting_logs = current_user.tasting_logs.includes(:beverage).order(created_at: :desc)
+  end
+
+  def new
+    @tasting_log = current_user.tasting_logs.new
+  end
+
+  def create
+    @tasting_log = current_user.tasting_logs.new(tasting_log_params)
+    if @tasting_log.save
+      redirect_to @tasting_log, notice: "記録を作成しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show; end
+
+  def destroy
+    @tasting_log.destroy!
+    redirect_to tasting_logs_path, notice: "記録を削除しました"
+  end
+
+  private
+
+  def set_tasting_log
+    @tasting_log = current_user.tasting_logs.find(params[:id]) # 他人の記録は見れない
+  end
+
+  def tasting_log_params
+    params.require(:tasting_log).permit(:beverage_id, :tasted_on, :rating, :comment)
+  end
+end

--- a/app/helpers/tasting_logs_helper.rb
+++ b/app/helpers/tasting_logs_helper.rb
@@ -1,0 +1,2 @@
+module TastingLogsHelper
+end

--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -1,3 +1,7 @@
 class Beverage < ApplicationRecord
   belongs_to :category
+
+  has_many :tasting_logs, dependent: :destroy
+  has_many :users, through: :tasting_logs
+
 end

--- a/app/models/tasting_log.rb
+++ b/app/models/tasting_log.rb
@@ -1,0 +1,6 @@
+class TastingLog < ApplicationRecord
+  belongs_to :user
+  belongs_to :beverage
+
+  validates :rating, inclusion: { in: 1..5 }, allow_nil: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :tasting_logs, dependent: :destroy
+  has_many :beverages, through: :tasting_logs
+
 end

--- a/app/views/tasting_logs/index.html.erb
+++ b/app/views/tasting_logs/index.html.erb
@@ -1,0 +1,17 @@
+<h1>飲酒記録一覧</h1>
+
+<p><%= link_to "新しい記録を作る", new_tasting_log_path %></p>
+
+<ul>
+  <% @tasting_logs.each do |log| %>
+    <li>
+      <%= link_to log.beverage.name, tasting_log_path(log) %>
+      <% if log.tasted_on.present? %>
+        （<%= log.tasted_on %>）
+      <% end %>
+      <% if log.rating.present? %>
+        ★<%= log.rating %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/tasting_logs/new.html.erb
+++ b/app/views/tasting_logs/new.html.erb
@@ -1,0 +1,37 @@
+<h1>飲酒記録を作成</h1>
+
+<%= form_with model: @tasting_log do |f| %>
+  <% if @tasting_log.errors.any? %>
+    <ul>
+      <% @tasting_log.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <div>
+    <%= f.label :beverage_id, "お酒" %><br>
+    <%= f.collection_select :beverage_id, Beverage.order(:name), :id, :name, prompt: "選択してください" %>
+  </div>
+
+  <div>
+    <%= f.label :tasted_on, "飲んだ日" %><br>
+    <%= f.date_field :tasted_on %>
+  </div>
+
+  <div>
+    <%= f.label :rating, "評価（1〜5）" %><br>
+    <%= f.number_field :rating, in: 1..5, step: 1 %>
+  </div>
+
+  <div>
+    <%= f.label :comment, "感想" %><br>
+    <%= f.text_area :comment, rows: 5 %>
+  </div>
+
+  <div>
+    <%= f.submit "保存" %>
+  </div>
+<% end %>
+
+<p><%= link_to "一覧に戻る", tasting_logs_path %></p>

--- a/app/views/tasting_logs/show.html.erb
+++ b/app/views/tasting_logs/show.html.erb
@@ -1,0 +1,20 @@
+<h1>飲酒記録</h1>
+
+<p><strong>お酒：</strong><%= @tasting_log.beverage.name %></p>
+
+<% if @tasting_log.tasted_on.present? %>
+  <p><strong>飲んだ日：</strong><%= @tasting_log.tasted_on %></p>
+<% end %>
+
+<% if @tasting_log.rating.present? %>
+  <p><strong>評価：</strong>★<%= @tasting_log.rating %></p>
+<% end %>
+
+<% if @tasting_log.comment.present? %>
+  <p><strong>感想：</strong><br><%= simple_format(@tasting_log.comment) %></p>
+<% end %>
+
+<p>
+  <%= link_to "一覧に戻る", tasting_logs_path %> |
+  <%= link_to "削除", tasting_log_path(@tasting_log), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
+  get 'tasting_logs/index'
+  get 'tasting_logs/new'
+  get 'tasting_logs/show'
   devise_for :users
 
   root "pages#home"
 
   resources :beverages, only: %i[index show]
+  resources :tasting_logs, only: %i[index new create show destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end

--- a/db/migrate/20251215145307_create_tasting_logs.rb
+++ b/db/migrate/20251215145307_create_tasting_logs.rb
@@ -1,0 +1,13 @@
+class CreateTastingLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tasting_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :beverage, null: false, foreign_key: true
+      t.date :tasted_on
+      t.integer :rating
+      t.text :comment
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_15_100723) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_15_145307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,18 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_15_100723) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "tasting_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "beverage_id", null: false
+    t.date "tasted_on"
+    t.integer "rating"
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["beverage_id"], name: "index_tasting_logs_on_beverage_id"
+    t.index ["user_id"], name: "index_tasting_logs_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -42,4 +54,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_15_100723) do
   end
 
   add_foreign_key "beverages", "categories"
+  add_foreign_key "tasting_logs", "beverages"
+  add_foreign_key "tasting_logs", "users"
 end


### PR DESCRIPTION
## 概要
ログインユーザーが「飲んだお酒の記録」を残せる機能を追加しました。
MVPとして、最小構成の記録作成・一覧・詳細・削除までを実装しています。

## 実装内容
- TastingLog モデルの追加（User / Beverage に紐付け）
- 記録一覧・作成・詳細・削除（CRUD最小構成）
- 未ログイン時は Devise によりログイン画面へリダイレクト
- 記録は current_user にのみ紐付くよう制御（他ユーザーの記録は参照不可）

## 画面
- `/tasting_logs`：自分の飲酒記録一覧
- `/tasting_logs/new`：記録作成
- `/tasting_logs/:id`：記録詳細

## 動作確認
- ログイン状態で記録の作成・表示・削除ができることを確認
- 未ログイン状態でアクセスした場合、`/users/sign_in` にリダイレクトされることを確認
- ローカル（Docker）環境で動作確認済み

## 備考
- rating は任意（1〜5）とし、MVP段階では最小限のバリデーションのみ実装
- 本番（Render）では `db:migrate` によりテーブル作成される想定