### PR TITLE
feat: add i18n (ja.yml) and navigation UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "bootsnap", require: false
 
 gem "devise"
 
+gem "rails-i18n"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.6)
       actionpack (= 7.1.6)
       activesupport (= 7.1.6)
@@ -253,6 +256,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)
+  rails-i18n
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/controllers/tasting_logs_controller.rb
+++ b/app/controllers/tasting_logs_controller.rb
@@ -13,7 +13,7 @@ class TastingLogsController < ApplicationController
   def create
     @tasting_log = current_user.tasting_logs.new(tasting_log_params)
     if @tasting_log.save
-      redirect_to @tasting_log, notice: "記録を作成しました"
+      redirect_to tasting_logs_path, notice: t("flash.created")
     else
       render :new, status: :unprocessable_entity
     end
@@ -23,7 +23,7 @@ class TastingLogsController < ApplicationController
 
   def destroy
     @tasting_log.destroy!
-    redirect_to tasting_logs_path, notice: "記録を削除しました"
+    redirect_to tasting_logs_path, notice: t("flash.deleted")
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,19 +1,23 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>App</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
+<header>
+  <nav style="display:flex; gap:12px; padding:12px; border-bottom:1px solid #ddd;">
+    <%= link_to t("app.name"), root_path %>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_importmap_tags %>
-  </head>
+    <% if user_signed_in? %>
+      <%= link_to t("nav.beverages"), beverages_path %>
+      <%= link_to t("nav.tasting_logs"), tasting_logs_path %>
+      <%= link_to t("nav.new_tasting_log"), new_tasting_log_path %>
 
-  <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
+      <span style="margin-left:auto;">
+        <%= link_to t("nav.logout"),
+                    destroy_user_session_path,
+                    data: { turbo_method: :delete } %>
+      </span>
+    <% else %>
+      <span style="margin-left:auto;">
+        <%= link_to t("nav.login"), new_user_session_path %>
+        <%= link_to t("nav.signup"), new_user_registration_path %>
+      </span>
+    <% end %>
+  </nav>
+</header>
 
-    <%= yield %>
-  </body>
-</html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,2 +1,13 @@
-<h1>Pages#home</h1>
-<p>Find me in app/views/pages/home.html.erb</p>
+<h1><%= t("app.name") %></h1>
+<p><%= t("app.tagline") %></p>
+
+<% if user_signed_in? %>
+  <p>
+    <%= link_to t("pages.home.cta.record"), new_tasting_log_path %> |
+    <%= link_to t("pages.home.cta.browse"), beverages_path %>
+  </p>
+<% else %>
+  <p>
+    <%= link_to t("pages.home.cta.login_to_start"), new_user_session_path %>
+  </p>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,9 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = [:ja]
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,25 @@
+ja:
+  app:
+    name: "sake手帳"
+    short_name: "sake手帳"
+    tagline: "今日飲んだお酒を、気軽に記録できるテイスティングログ。"
+
+  nav:
+    beverages: "お酒一覧"
+    tasting_logs: "飲酒記録"
+    new_tasting_log: "記録する"
+    login: "ログイン"
+    signup: "新規登録"
+    logout: "ログアウト"
+
+  pages:
+    home:
+      cta:
+        record: "飲酒記録をつける"
+        browse: "お酒一覧を見る"
+        login_to_start: "ログインして始めましょう"
+  
+  flash:
+    created: "作成しました"
+    updated: "更新しました"
+    deleted: "削除しました"


### PR DESCRIPTION
## 概要
UI整備としてナビゲーションとTOPの導線を追加し、表示文言を ja.yml（I18n）経由に統一。

## 対応内容
- `rails-i18n` を導入
- `config.i18n.default_locale = :ja` を設定
- `config/locales/ja.yml` を追加し、ナビ/トップ文言をキー管理に変更
- ログイン状態に応じてナビ表示を切り替え（ログイン/新規登録 or ログアウト）
- TOPに主要導線（お酒一覧 / 記録作成など）を追加

## 動作確認
- ローカル（Docker）で表示・導線を確認しました。
- ログイン前後でナビが切り替わることを確認しました。