### PR TITLE
feat: お気に入り登録を実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,17 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_beverage
+
+  def create
+    current_user.favorites.find_or_create_by!(beverage: @beverage)
+    redirect_back fallback_location: beverages_path, notice: "お気に入りに追加しました"
+  rescue ActiveRecord::RecordInvalid
+    redirect_back fallback_location: beverages_path, alert: "お気に入りに追加できませんでした"
+  end
+
+  private
+
+  def set_beverage
+    @beverage = Beverage.find(params[:beverage_id])
+  end
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -3,5 +3,6 @@ class Beverage < ApplicationRecord
 
   has_many :tasting_logs, dependent: :destroy
   has_many :users, through: :tasting_logs
+  has_many :favorites, dependent: :destroy
 
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :beverage
+
+  validates :user_id, uniqueness: { scope: :beverage_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,7 @@ class User < ApplicationRecord
 
   has_many :tasting_logs, dependent: :destroy
   has_many :beverages, through: :tasting_logs
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_beverages, through: :favorites, source: :beverage
 
 end

--- a/app/views/beverages/index.html.erb
+++ b/app/views/beverages/index.html.erb
@@ -5,6 +5,14 @@
     <li>
       <%= link_to beverage.name, beverage_path(beverage) %>
       （<%= beverage.category.name %>）
+
+      <% if user_signed_in? %>
+        <%= button_to "お気に入り",
+                      beverage_favorite_path(beverage),
+                      method: :post,
+                      class: "btn btn-outline-primary btn-sm" %>
+      <% end %>
     </li>
   <% end %>
 </ul>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
 
   root "pages#home"
 
-  resources :beverages, only: %i[index show]
+  resources :beverages, only: %i[index show] do
+    resource :favorite, only: %i[create]
+  end
+
   resources :tasting_logs, only: %i[index new create show destroy]
 
   get "up" => "rails/health#show", as: :rails_health_check

--- a/db/migrate/20251216065646_create_favorites.rb
+++ b/db/migrate/20251216065646_create_favorites.rb
@@ -1,0 +1,10 @@
+class CreateFavorites < ActiveRecord::Migration[7.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :beverage, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251216070052_add_unique_index_to_favorites.rb
+++ b/db/migrate/20251216070052_add_unique_index_to_favorites.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToFavorites < ActiveRecord::Migration[7.1]
+  def change
+    add_index :favorites, %i[user_id beverage_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_15_145307) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_16_070052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,16 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_15_145307) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "beverage_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["beverage_id"], name: "index_favorites_on_beverage_id"
+    t.index ["user_id", "beverage_id"], name: "index_favorites_on_user_id_and_beverage_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "tasting_logs", force: :cascade do |t|
@@ -54,6 +64,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_15_145307) do
   end
 
   add_foreign_key "beverages", "categories"
+  add_foreign_key "favorites", "beverages"
+  add_foreign_key "favorites", "users"
   add_foreign_key "tasting_logs", "beverages"
   add_foreign_key "tasting_logs", "users"
 end


### PR DESCRIPTION
## 概要
お酒をお気に入り登録できる機能を追加しました。

## 対応内容
- Favoriteモデル追加（user×beverage）
- 二重登録防止（バリデーション＋ユニークIndex）
- beverages一覧にお気に入り登録ボタン追加
- 登録成功/失敗のフラッシュ表示

## 確認方法
- ログイン後、お酒一覧から「お気に入り」を押す
- フラッシュが表示されること
- 同一ユーザーが同一お酒を重複登録できないこと