### PR TITLE
feat: お気に入り解除機能を実装

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -5,8 +5,12 @@ class FavoritesController < ApplicationController
   def create
     current_user.favorites.find_or_create_by!(beverage: @beverage)
     redirect_back fallback_location: beverages_path, notice: "お気に入りに追加しました"
-  rescue ActiveRecord::RecordInvalid
-    redirect_back fallback_location: beverages_path, alert: "お気に入りに追加できませんでした"
+  end
+
+  def destroy
+    favorite = current_user.favorites.find_by(beverage: @beverage)
+    favorite&.destroy
+    redirect_back fallback_location: beverages_path, notice: "お気に入りを解除しました"
   end
 
   private

--- a/app/views/beverages/index.html.erb
+++ b/app/views/beverages/index.html.erb
@@ -7,10 +7,17 @@
       （<%= beverage.category.name %>）
 
       <% if user_signed_in? %>
-        <%= button_to "お気に入り",
-                      beverage_favorite_path(beverage),
-                      method: :post,
-                      class: "btn btn-outline-primary btn-sm" %>
+        <% if current_user.favorites.exists?(beverage: beverage) %>
+          <%= button_to "お気に入り解除",
+                        beverage_favorite_path(beverage),
+                        method: :delete,
+                        class: "btn btn-outline-danger btn-sm" %>
+        <% else %>
+          <%= button_to "お気に入り",
+                        beverage_favorite_path(beverage),
+                        method: :post,
+                        class: "btn btn-outline-primary btn-sm" %>
+        <% end %>
       <% end %>
     </li>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   root "pages#home"
 
   resources :beverages, only: %i[index show] do
-    resource :favorite, only: %i[create]
+    resource :favorite, only: %i[create destroy]
   end
 
   resources :tasting_logs, only: %i[index new create show destroy]


### PR DESCRIPTION
## 概要
お気に入り登録済みのお酒を解除できる機能を追加しました。

## 対応内容
- favorites に destroy アクションを追加
- 登録/解除ボタンを状態に応じて出し分け
- 解除後にフラッシュメッセージを表示

## 確認方法
- お酒一覧でお気に入り登録後、解除できること
- 表示が正しく切り替わること
