### PR TITLE
feat: お気に入り一覧（/favorites）を追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,10 @@
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_beverage
+  before_action :set_beverage, only: %i[create destroy]
+
+  def index
+    @beverages = current_user.favorite_beverages.includes(:category)
+  end
 
   def create
     current_user.favorites.find_or_create_by!(beverage: @beverage)

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,19 @@
+<h1>お気に入り一覧</h1>
+
+<% if @beverages.any? %>
+  <ul>
+    <% @beverages.each do |beverage| %>
+      <li>
+        <%= link_to beverage.name, beverage_path(beverage) %>
+        （<%= beverage.category.name %>）
+
+        <%= button_to "お気に入り解除",
+                      beverage_favorite_path(beverage),
+                      method: :delete,
+                      class: "btn btn-outline-danger btn-sm" %>
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>お気に入りはまだありません。</p>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
       <% if user_signed_in? %>
         <%= link_to t("nav.beverages"), beverages_path %>
         <%= link_to t("nav.tasting_logs"), tasting_logs_path %>
+        <%= link_to "お気に入り", favorites_path %>
         <%= link_to t("nav.new_tasting_log"), new_tasting_log_path %>
 
         <span style="margin-left:auto;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   end
 
   resources :tasting_logs, only: %i[index new create show destroy]
+  resources :favorites, only: %i[index]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## 概要
お気に入り登録したお酒を一覧表示できるページ（/favorites）を追加しました。
一覧からお気に入り解除も可能です。

## 対応内容
- favorites#index を追加し、current_user のお気に入りお酒一覧を表示
- N+1を避けるため includes(:category) を付与
- 一覧からお気に入り解除（DELETE）できるボタンを追加
- ナビゲーションに「お気に入り」への導線を追加
- before_action の適用範囲を見直し、index で set_beverage が走らないよう修正

## 確認方法
1. ログインする
2. お酒一覧で任意のお酒をお気に入り登録する
3. ナビの「お気に入り」または `/favorites` にアクセスする
4. お気に入りしたお酒が一覧表示されること
5. 一覧の「お気に入り解除」を押すと、一覧から削除されること