### PR TITLE
feat: マイページを追加

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,9 @@
 class PagesController < ApplicationController
-  def home
+  before_action :authenticate_user!, only: %i[mypage]
+
+  def home; end
+
+  def mypage
+    @user = current_user
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
       <%= link_to t("app.name"), root_path %>
 
       <% if user_signed_in? %>
+        <%= link_to "マイページ", mypage_path %>
         <%= link_to t("nav.beverages"), beverages_path %>
         <%= link_to t("nav.tasting_logs"), tasting_logs_path %>
         <%= link_to "お気に入り", favorites_path %>

--- a/app/views/pages/mypage.html.erb
+++ b/app/views/pages/mypage.html.erb
@@ -1,0 +1,19 @@
+<h1>マイページ</h1>
+
+<p>
+  ログイン中：<strong><%= @user.email %></strong>
+</p>
+
+<hr>
+
+<ul>
+  <li>
+    <%= link_to "飲酒記録一覧", tasting_logs_path %>
+    （<%= @user.tasting_logs.count %>件）
+  </li>
+
+  <li>
+    <%= link_to "お気に入り一覧", favorites_path %>
+    （<%= @user.favorites.count %>件）
+  </li>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,8 @@
 Rails.application.routes.draw do
-  get 'tasting_logs/index'
-  get 'tasting_logs/new'
-  get 'tasting_logs/show'
   devise_for :users
 
   root "pages#home"
+  get "mypage", to: "pages#mypage"
 
   resources :beverages, only: %i[index show] do
     resource :favorite, only: %i[create destroy]


### PR DESCRIPTION
## 概要
ログインユーザー向けにマイページ（/mypage）を追加しました。
飲酒記録・お気に入りへの導線をまとめ、ユーザー単位の操作導線を整理しています。

## 対応内容
- /mypage ルーティングを追加
- pages#mypage を追加（ログイン必須）
- マイページにユーザー情報と各一覧へのリンクを表示
- 飲酒記録数・お気に入り数を表示

## 確認方法
1. 未ログインで /mypage にアクセス → ログイン画面に遷移する
2. ログイン後 /mypage にアクセス → マイページが表示される
3. 「飲酒記録一覧」「お気に入り一覧」へ遷移できる