### PR TITLE
moods/beverage_moods モデルの追加

### DIFF
--- a/app/models/beverage.rb
+++ b/app/models/beverage.rb
@@ -4,5 +4,7 @@ class Beverage < ApplicationRecord
   has_many :tasting_logs, dependent: :destroy
   has_many :users, through: :tasting_logs
   has_many :favorites, dependent: :destroy
+  has_many :beverage_moods, dependent: :destroy
+has_many :moods, through: :beverage_moods
 
 end

--- a/app/models/beverage_mood.rb
+++ b/app/models/beverage_mood.rb
@@ -1,0 +1,6 @@
+class BeverageMood < ApplicationRecord
+  belongs_to :beverage
+  belongs_to :mood
+
+  validates :beverage_id, uniqueness: { scope: :mood_id }
+end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -1,0 +1,6 @@
+class Mood < ApplicationRecord
+  has_many :beverage_moods, dependent: :destroy
+  has_many :beverages, through: :beverage_moods
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/db/migrate/20251216150244_create_moods.rb
+++ b/db/migrate/20251216150244_create_moods.rb
@@ -1,0 +1,9 @@
+class CreateMoods < ActiveRecord::Migration[7.1]
+  def change
+    create_table :moods do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251216150258_create_beverage_moods.rb
+++ b/db/migrate/20251216150258_create_beverage_moods.rb
@@ -1,0 +1,10 @@
+class CreateBeverageMoods < ActiveRecord::Migration[7.1]
+  def change
+    create_table :beverage_moods do |t|
+      t.references :beverage, null: false, foreign_key: true
+      t.references :mood, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251216150453_add_unique_index_to_beverage_moods.rb
+++ b/db/migrate/20251216150453_add_unique_index_to_beverage_moods.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToBeverageMoods < ActiveRecord::Migration[7.1]
+  def change
+    add_index :beverage_moods, %i[beverage_id mood_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_12_16_070052) do
+ActiveRecord::Schema[7.1].define(version: 2025_12_16_150453) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "beverage_moods", force: :cascade do |t|
+    t.bigint "beverage_id", null: false
+    t.bigint "mood_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["beverage_id", "mood_id"], name: "index_beverage_moods_on_beverage_id_and_mood_id", unique: true
+    t.index ["beverage_id"], name: "index_beverage_moods_on_beverage_id"
+    t.index ["mood_id"], name: "index_beverage_moods_on_mood_id"
+  end
 
   create_table "beverages", force: :cascade do |t|
     t.string "name"
@@ -39,6 +49,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_16_070052) do
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
+  create_table "moods", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "tasting_logs", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "beverage_id", null: false
@@ -63,6 +79,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_12_16_070052) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "beverage_moods", "beverages"
+  add_foreign_key "beverage_moods", "moods"
   add_foreign_key "beverages", "categories"
   add_foreign_key "favorites", "beverages"
   add_foreign_key "favorites", "users"


### PR DESCRIPTION
## 概要
お酒を「気分（mood）」で分類できるようにするための基盤として、
moods および beverage_moods のモデル・関連付けを追加しました。

## 対応内容
- Mood モデルを追加
- Beverage と Mood の多対多関係を担う BeverageMood モデルを追加
- 各モデルに関連付け（has_many / through）を定義
- 重複登録防止のため、以下の制約を追加
  - バリデーション（beverage_id × mood_id の一意性）
  - DBレベルのユニークインデックス

## 設計意図
- お酒（Beverage）と気分（Mood）は多対多関係となるため、中間テーブルを採用
- 本Issueではデータ構造の整備に留め、画面表示やseed登録は後続Issueで対応予定

## 確認方法
- `rails db:migrate` が正常に完了すること
- Railsコンソールで以下が確認できること
  - `Mood.create!(name: "...")` が作成できる
  - `beverage.moods` / `mood.beverages` で関連が取得できる