### PR TITLE
moods / beverage_moods のseedデータを追加

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,18 +9,29 @@
 #   end
 Category.destroy_all
 Beverage.destroy_all
+Mood.destroy_all
+BeverageMood.destroy_all
 
 sake = Category.create!(name: "日本酒")
-beer = Category.create!(name: "ビール")
+beer_category = Category.create!(name: "ビール")
 
-Beverage.create!(
+dassai = Beverage.create!(
   name: "獺祭 純米大吟醸",
   description: "華やかな香りとキレのある後味が特徴の日本酒。",
   category: sake
 )
 
-Beverage.create!(
+yonayona = Beverage.create!(
   name: "よなよなエール",
   description: "柑橘系の香りとコクが楽しめるクラフトビール。",
-  category: beer
+  category: beer_category
 )
+
+# --- moods 作成 ---
+%w[リラックス 気分転換 祝い しっぽり].each do |name|
+  Mood.find_or_create_by!(name: name)
+end
+
+# --- 紐付け（beverage_moods） ---
+BeverageMood.find_or_create_by!(beverage: yonayona, mood: Mood.find_by!(name: "気分転換"))
+BeverageMood.find_or_create_by!(beverage: dassai, mood: Mood.find_by!(name: "しっぽり"))


### PR DESCRIPTION
## 概要
moods / beverage_moods 機能の動作確認を行うため、
開発環境向けのseedデータを追加しました。

## 対応内容
- Mood（気分）マスターデータのseedを追加
  - リラックス / 気分転換 / 祝い / しっぽり
- Beverage と Mood の関連（beverage_moods）をseedで登録
- 既存の Category / Beverage seed と整合する形で実装

## 設計意図
- UI実装（Issue19）前に、関連データを簡単に確認できる状態を作るため
- 本番環境では seed を実行しない運用のため、開発確認用途に限定

## 確認方法
1. `rails db:seed` を実行する
2. Mood レコードが作成されていることを確認
3. `beverage.moods` / `mood.beverages` で関連が取得できることを確認
