### PR TITLE
feat: 気分選択からおすすめ一覧を表示する機能を追加

### DIFF
--- a/app/controllers/moods_controller.rb
+++ b/app/controllers/moods_controller.rb
@@ -1,0 +1,10 @@
+class MoodsController < ApplicationController
+  def index
+    @moods = Mood.order(:name)
+  end
+
+  def show
+    @mood = Mood.find(params[:id])
+    @beverages = @mood.beverages.includes(:category)
+  end
+end

--- a/app/helpers/moods_helper.rb
+++ b/app/helpers/moods_helper.rb
@@ -1,0 +1,2 @@
+module MoodsHelper
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
 
       <% if user_signed_in? %>
         <%= link_to "マイページ", mypage_path %>
+        <%= link_to "気分で選ぶ", moods_path %>
         <%= link_to t("nav.beverages"), beverages_path %>
         <%= link_to t("nav.tasting_logs"), tasting_logs_path %>
         <%= link_to "お気に入り", favorites_path %>

--- a/app/views/moods/index.html.erb
+++ b/app/views/moods/index.html.erb
@@ -1,0 +1,7 @@
+<h1>気分で選ぶ</h1>
+
+<ul>
+  <% @moods.each do |mood| %>
+    <li><%= link_to mood.name, mood_path(mood) %></li>
+  <% end %>
+</ul>

--- a/app/views/moods/show.html.erb
+++ b/app/views/moods/show.html.erb
@@ -1,0 +1,14 @@
+<h1><%= @mood.name %> のおすすめ</h1>
+
+<% if @beverages.any? %>
+  <ul>
+    <% @beverages.each do |beverage| %>
+      <li>
+        <%= link_to beverage.name, beverage_path(beverage) %>
+        （<%= beverage.category.name %>）
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>この気分に紐づくお酒がまだありません。</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'moods/index'
+  get 'moods/show'
   devise_for :users
 
   root "pages#home"
@@ -10,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :tasting_logs, only: %i[index new create show destroy]
   resources :favorites, only: %i[index]
+  resources :moods, only: %i[index show]
 
   get "up" => "rails/health#show", as: :rails_health_check
 end


### PR DESCRIPTION
## 概要
ユーザーが気分（Mood）を選択し、その気分に紐づいたお酒（Beverage）の
おすすめ一覧を確認できる機能を追加しました。

## 対応内容
- moods#index を追加し、気分一覧を表示
- moods#show を追加し、選択した気分に紐づくお酒一覧を表示
- Mood と Beverage の関連（beverage_moods）を利用した取得処理を実装
- 一覧表示時に includes を使用し、N+1問題を回避

## 設計意図
- Issue10 / Issue18 で整備したデータ構造・seedを活用し、UIレイヤーを実装
- 「気分 → お酒」という直感的な導線を提供し、アプリの拡張価値を示すことを目的としています
- MVPを崩さないよう、表示機能に絞った最小構成としています

## 確認方法
1. seedデータ投入後（Issue18）に `/moods` へアクセスする
2. 気分一覧が表示されることを確認
3. 任意の気分を選択する
4. その気分に紐づいたお酒一覧が表示されることを確認
5. 紐づくお酒がない場合は、案内文が表示されることを確認